### PR TITLE
TestEntityHelper: avoid conflicts on 8080

### DIFF
--- a/starter-kit/src/test/java/it/spid/cie/oidc/helper/TestEntityHelper.java
+++ b/starter-kit/src/test/java/it/spid/cie/oidc/helper/TestEntityHelper.java
@@ -23,7 +23,7 @@ public class TestEntityHelper {
 
 	@BeforeClass
 	public static void setUp() throws IOException {
-		wireMockServer = new WireMockServer();
+		wireMockServer = new WireMockServer(18000);
 
 		wireMockServer.start();
 


### PR DESCRIPTION
Add missing `18000` port (like other helpers) to avoid test failures when `8080` is already in use.